### PR TITLE
⬆️ upgrade ruby, gems [NFR-609]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
-ruby '2.6.6'
+ruby '3.1.2'
 
-gem 'fluentd', '~> 1.2.6'
-gem 'fluent-plugin-newrelic', '~> 1.1.8'
+gem 'fluentd', '~> 1.2'
+gem 'fluent-plugin-newrelic', '~> 1.1'
 gem 'fluent-plugin-heroku-http', '~> 0.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,43 +1,47 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    cool.io (1.6.0)
-    dig_rb (1.0.1)
-    fluent-plugin-heroku-http (0.0.1)
+    concurrent-ruby (1.1.10)
+    cool.io (1.7.1)
+    fluent-plugin-heroku-http (0.0.2)
       fluentd (>= 1.0)
-    fluent-plugin-newrelic (1.1.8)
+    fluent-plugin-newrelic (1.1.10)
       fluentd (>= 1.0.0)
-    fluentd (1.2.6)
+    fluentd (1.15.1)
+      bundler
       cool.io (>= 1.4.5, < 2.0.0)
-      dig_rb (~> 1.0.0)
-      http_parser.rb (>= 0.5.1, < 0.7.0)
-      msgpack (>= 0.7.0, < 2.0.0)
-      serverengine (>= 2.0.4, < 3.0.0)
+      http_parser.rb (>= 0.5.1, < 0.9.0)
+      msgpack (>= 1.3.1, < 2.0.0)
+      serverengine (>= 2.3.0, < 3.0.0)
       sigdump (~> 0.2.2)
-      strptime (>= 0.2.2, < 1.0.0)
-      tzinfo (~> 1.0)
+      strptime (>= 0.2.4, < 1.0.0)
+      tzinfo (>= 1.0, < 3.0)
       tzinfo-data (~> 1.0)
+      webrick (>= 1.4.2, < 1.8.0)
       yajl-ruby (~> 1.0)
-    http_parser.rb (0.6.0)
-    msgpack (1.3.3)
-    serverengine (2.2.1)
+    http_parser.rb (0.8.0)
+    msgpack (1.5.4)
+    serverengine (2.3.0)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
-    strptime (0.2.3)
-    thread_safe (0.3.6)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    tzinfo-data (1.2019.3)
+    strptime (0.2.5)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
-    yajl-ruby (1.4.1)
+    webrick (1.7.0)
+    yajl-ruby (1.4.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   fluent-plugin-heroku-http (~> 0.0.1)
-  fluent-plugin-newrelic (~> 1.1.8)
-  fluentd (~> 1.2.6)
+  fluent-plugin-newrelic (~> 1.1)
+  fluentd (~> 1.2)
+
+RUBY VERSION
+   ruby 3.1.2p20
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
 * upgrade Ruby to 3.1.2
 * relax constraints on gems and upgrade so we get Ruby-3-compatible versions

Co-authored-by: Mark Urich <markurich@gmail.com>